### PR TITLE
add parameter ALLOWED_HOSTS to authorize containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A simple X11 server block, which starts [matchbox window manager](https://www.us
 
 ## Usage
 
-Set the `DISPLAY` variable in your application to `localhost:0` before running any GUI applications
+Set the `DISPLAY` variable in your application to `<xserver host>:0` where <xserver host> is the name of the container running the X server before running any GUI applications. Set `ALLOWED_HOSTS` to a comma delimited string of hosts that need to connect to the server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,15 @@
 version: "2"
 services:
-  x11:
+  xserver:
     build: ./
     restart: always
     privileged: true
-    network_mode: host
+    environment:
+      ALLOWED_HOSTS: xeyes
   xeyes:
     build: ./example/xeyes
+    environment:
+      DISPLAY: xserver:0
     restart: always
-    privileged: true
-    network_mode: host
     depends_on:
-      - x11
+      - xserver

--- a/example/xeyes/Dockerfile.template
+++ b/example/xeyes/Dockerfile.template
@@ -2,6 +2,4 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:buster
 
 RUN install_packages x11-apps
 
-ENV DISPLAY=localhost:0
-
 ENTRYPOINT  ["xeyes"]

--- a/xinitrc
+++ b/xinitrc
@@ -1,4 +1,18 @@
-xhost +localhost
+ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost}
+
+IFS=","; for host in $ALLOWED_HOSTS; do
+	# wait for host to show up
+	while true; do
+		if getent hosts $host > /dev/null; then
+			break
+		fi
+
+		echo "$host is unavailable, waiting..."
+		sleep 0.1
+	done
+	xhost +$host
+done
+
 xset s off -dpms
 
 if [ "$CURSOR" = true ]; 


### PR DESCRIPTION
Instead of authorizing all connections from localhost, explicitly
authorize connections from containers named in the ALLOWED_HOSTS
environment variable.

Signed-off-by: Joseph Kogut <joseph@balena.io>