### PR TITLE
Dockerfile.template: use debian bullseye-20210705

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 ARG BALENA_ARCH=%%BALENA_ARCH%%
 
-FROM balenalib/$BALENA_ARCH-debian:buster
+FROM balenalib/$BALENA_ARCH-debian:bullseye-20210705
 
 RUN install_packages \
     matchbox-window-manager \


### PR DESCRIPTION
Use debian bullseye-20210705 tag as base image for newer hardware
support.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>