### PR TITLE
docker-compose: setup dri node w/ perms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,9 @@ services:
   glxgears:
     build: ./example/glxgears
     restart: always
+    devices:
+      - /dev/dri
+    group_add:
+      - video
     volumes:
       - 'xserver:/tmp/.X11-unix'


### PR DESCRIPTION
Add /dev/dri devices to service requiring graphics acceleration, and add
video group for permission to access dri nodes.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>