### PR TITLE
Dockerfile: remove mesa-vdpau-drivers

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,7 +4,6 @@ FROM balenalib/$BALENA_ARCH-debian:bullseye
 
 RUN install_packages \
     matchbox-window-manager \
-    mesa-vdpau-drivers \
     x11-xserver-utils \
     x11-utils \
     xauth \


### PR DESCRIPTION
These drivers aren't used by the X server.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>