### PR TITLE
fix: hide-cursor-from-screen

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -19,4 +19,9 @@ then
 	fi
 fi
 
-exec startx
+if [ "$CURSOR" = true ];
+then
+    exec startx
+else
+    exec startx -- -nocursor
+fi

--- a/src/xinitrc
+++ b/src/xinitrc
@@ -3,9 +3,4 @@ xset s off -dpms
 
 bash /opt/xserver/config.sh
 
-if [ "$CURSOR" = true ]; 
-then
-    matchbox-window-manager -use_titlebar no
-else
-    matchbox-window-manager -use_titlebar no -use_cursor no
-fi
+matchbox-window-manager -use_titlebar no


### PR DESCRIPTION
leverage the startx to hide the cursor instead of the xinitrc