### PR TITLE
Change balena.yml type to sw.block

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -2,7 +2,7 @@ name: xserver
 description: >-
   A simple block that runs an X server for GUI applications
 version: 0.0.7
-type: sw.application
+type: sw.block
 assets:
   repository:
     type: blob.asset


### PR DESCRIPTION
xserver is deployed as blocks and not apps. This changes the balena.yml file accordingly. 

Change-type: minor